### PR TITLE
Adapt to scientific '1.0E-3' floats format

### DIFF
--- a/ENDF6.py
+++ b/ENDF6.py
@@ -50,7 +50,11 @@ def read_float(v):
     Convert ENDF6 string to float
     (the ENDF6 float representation omits the e for exponent and may contain blanks)
     """
-    return float( v[0]+v[1:].replace(' ', '').replace('+', 'e+').replace('-', 'e-') )
+    try:
+        number = float(v[0]+v[1:].replace(' ', ''))
+    except ValueError:
+        number = float( v[0]+v[1:].replace(' ', '').replace('+', 'e+').replace('-', 'e-') )
+    return number
 
 def read_line(l):
     """Read first 6*11 characters of a line as floats"""


### PR DESCRIPTION
The contemporary [PREPRO](https://www-nds.iaea.org/public/endf/prepro/) codes for working with ENDF file format tend to convert the floats format `'1.000-3'` into a standard format `'1.000E-3'` which is compatible with FORTRAN, C, C++ and others. This seems to be the recommended way of working with ENDF files today. Here is an excerpt from the official PREPRO [documentation](https://www-nds.iaea.org/publications/nds/iaea-nds-0039/):

> 1) ENDF2C - is a new code for PREPRO 2017, that is designed to insure that ALL PREPRO output in the ENDF format are completely FORTRAN, C and C++ compatible. As of today (January 2017) evaluated data even from major code centers are still not completely FORTRAN, C and C++ compatible. Therefore when I begin pre-processing any evaluation the first PREPRO code I run is ENDF2C to insure that ALL ENDF formatted output in subsequent codes are completely compatible. This is a very important step: it would be such a shame if after all of the effort invested to produce accurate results it cannot be accurately read and used by application codes.

And the files created this way cannot be read using the current ENDF6.py because of this discrepancy (see for example, the [POINT database](https://www-nds.iaea.org/point/)).

So I suggest a minor change in ENDF6.py code which allows to read both formats automatically.